### PR TITLE
Add missing repos

### DIFF
--- a/lib/ff-dev-env.js
+++ b/lib/ff-dev-env.js
@@ -19,7 +19,12 @@ options.packages = [
     'flowforge-nr-auth',
     'flowforge-nr-launcher',
     'flowforge-nr-storage',
-    'flowforge-nr-theme'
+    'flowforge-nr-theme',
+    'flowforge-driver-k8s',
+    'flowforge-driver-docker',
+    'installer',
+    'helm',
+    'docker-compose'
 ]
 
 if (options.command === 'init') {


### PR DESCRIPTION
This adds in the missing repos to the dev environment that are part of the release.

There is one exception - the `admin` repo that includes the release script. However, that is a private repo so not suitable to add to the dev environment.