### PR TITLE
setup: Fetch data through HTTP

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -13,7 +13,12 @@ async function run(options) {
             try {
                 await runner(
                     `${options.packages[i]}`,
-                    `git clone git@github.com:flowforge/${options.packages[i]}.git`,
+                    `git clone https://github.com/flowforge/${options.packages[i]}.git`,
+                    { cwd: options.packageDir }
+                )
+		await runner(
+                    `${options.packages[i]}`,
+                    `git remote set-url --push origin git@github.com:flowforge/${options.packages[i]}.git`,
                     { cwd: options.packageDir }
                 )
                 log(`${chalk.greenBright('+')} flowforge/${options.packages[i]}`)


### PR DESCRIPTION
For users that have not setup a GitHub account with SSH keys this
project does not allow them to obtain the repositories. HTTPS is for
them a better protocol, as it works without uploading a public key to
GitHub. Now HTTPS isn't great when pushing data though, as it requires a
password each time a push is done.

This change leverages Gits ability to differ the `fetch` remote URL and
the `push` remote URL. For the origin remote when setting up this
project it's using all HTTP, but right after the clone the `push` URL is
setup through the SSH/Git protocol.

Given only FlowForge team members will push changes to the root
repository, not forks, this works for the community and team members
alike.

Fixes: https://github.com/flowforge/flowforge-dev-env/issues/5