### PR TITLE
Fix repo push remote to use the right url

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -25,7 +25,7 @@ async function run(options) {
                 await runner(
                     `${options.packages[i]}`,
                     `git remote set-url --push origin git@github.com:flowforge/${options.packages[i]}.git`,
-                    { cwd: options.packageDir }
+                    { cwd: path.join(options.packageDir, options.packages[i]) }
                 )
                 log(`${chalk.greenBright('+')} flowforge/${options.packages[i]}`)
             } catch(err) {
@@ -36,9 +36,16 @@ async function run(options) {
                 return
             }
         } else {
+            // Ensure the push remote has been set to the git@ url
+            await runner(
+                `${options.packages[i]}`,
+                `git remote set-url --push origin git@github.com:flowforge/${options.packages[i]}.git`,
+                { cwd: path.join(options.packageDir, options.packages[i]) }
+            )
             log(` ${chalk.yellowBright('=')} flowforge/${options.packages[i]}`)
         }
     }
+    return
     log(chalk.bold('Installing packages'))
     try {
         await runner(

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -45,7 +45,6 @@ async function run(options) {
             log(` ${chalk.yellowBright('=')} flowforge/${options.packages[i]}`)
         }
     }
-    return
     log(chalk.bold('Installing packages'))
     try {
         await runner(


### PR DESCRIPTION
The init script was updated to set the push remote to use the `git@` url. However it was running the command in the wrong directory, so was actually setting the remote of the dev-env repo each time, not the sub-packages.

This fixes it to run the command in the right directory, but also runs it if the repo is already cloned - ie repair existing installed.