### PR TITLE
Add flowforge-nr-plugin to list of managed repos

### DIFF
--- a/lib/ff-dev-env.js
+++ b/lib/ff-dev-env.js
@@ -19,6 +19,7 @@ options.packages = [
     'flowforge-driver-docker',
     'flowforge-device-agent',
     'flowforge-file-server',
+    'flowforge-nr-plugin',
     'flowforge-nr-audit-logger',
     'flowforge-nr-auth',
     'flowforge-nr-launcher',


### PR DESCRIPTION
## Description

Adds `flowforge-nr-plugin` to the list of managed repos.

Once the work is done to retire the repos this replaces, I'll follow-up with a PR that removes the retired repos from the list and notify the user they can delete the directories.