### PR TITLE
Add check-dependencies action

### DIFF
--- a/lib/commands/checkDependencies.js
+++ b/lib/commands/checkDependencies.js
@@ -1,0 +1,46 @@
+const { existsSync } = require('fs')
+const { log } = require('console')
+const path = require('path')
+
+async function run (options) {
+    const chalk = (await import('chalk')).default
+
+    const packages = {}
+
+    log(chalk.bold('Checking repository packages'))
+    for (let i = 0; i < options.packages.length; i++) {
+        const packageFile = path.join(options.packageDir, options.packages[i], 'package.json')
+        if (existsSync(packageFile)) {
+            const packageDetails = require(packageFile)
+            if (packageDetails.dependencies) {
+                for (const [name, version] of Object.entries(packageDetails.dependencies)) {
+                    packages[name] = packages[name] || {}
+                    packages[name][version] = packages[name][version] || []
+                    packages[name][version].push({ package: options.packages[i] })
+                }
+            }
+            if (packageDetails.devDependencies) {
+                for (const [name, version] of Object.entries(packageDetails.devDependencies)) {
+                    packages[name] = packages[name] || {}
+                    packages[name][version] = packages[name][version] || []
+                    packages[name][version].push({ package: options.packages[i], dev: true })
+                }
+            }
+        }
+    }
+
+    for (const [name, details] of Object.entries(packages)) {
+        const versions = Object.keys(details)
+        versions.sort()
+        if (versions.length > 1) {
+            log(` ${chalk.bold(name)}`)
+            for (const version of versions) {
+                log(`  - ${version} : ${details[version].map(p => p.package).join(', ')}`)
+            }
+        }
+    }
+}
+
+module.exports = {
+    run
+}

--- a/lib/ff-dev-env.js
+++ b/lib/ff-dev-env.js
@@ -47,6 +47,8 @@ if (options.command === 'remove-unused') {
         require('./commands/update').run(options)
     } else if (options.command === 'git') {
         require('./commands/git').run(options)
+    } else if (options.command === 'check-dependencies') {
+        require('./commands/checkDependencies').run(options)
     } else {
         reportUsageAndExit()
     }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "status": "node lib/ff-dev-env.js status",
     "update": "node lib/ff-dev-env.js update",
     "git": "node lib/ff-dev-env.js git",
-    "remove-unused": "node lib/ff-dev-env.js remove-unused"
+    "remove-unused": "node lib/ff-dev-env.js remove-unused",
+    "check-dependencies": "node lib/ff-dev-env.js check-dependencies"
   },
   "workspaces": [
     "./packages/*"


### PR DESCRIPTION
## Description

Adds `npm run check-dependencies` to examine all package.json files and look for packages that are required multiple times at different levels.

We want to ensure we use consistent versions across all repositories. 

At the time of raising this PR, the output is as follows:

```
Checking repository packages
 sequelize
  - ^6.25.2 : flowforge
  - ^6.25.3 : flowforge-file-server
 yaml
  - ^2.1.1 : flowforge-device-agent
  - ^2.1.3 : flowforge, flowforge-file-server
 @babel/core
  - ^7.20.5 : forge-ui-components
  - ^7.20.7 : flowforge
 dotenv-webpack
  - ^7.1.1 : forge-ui-components
  - ^8.0.1 : flowforge
 eslint
  - ^8.25.0 : flowforge-driver-localfs, flowforge-driver-k8s, flowforge-driver-docker, flowforge-device-agent, flowforge-nr-launcher, flowforge-nr-project-nodes, flowforge-nr-file-nodes, flowforge-nr-persistent-context
  - ^8.26.0 : flowforge-file-server
  - ^8.29.0 : forge-ui-components
  - ^8.31.0 : flowforge
 mocha
  - ^10.0.0 : flowforge-device-agent, flowforge-nr-launcher
  - ^10.1.0 : flowforge-file-server, flowforge-nr-file-nodes, flowforge-nr-persistent-context
  - ^10.2.0 : flowforge
 pg
  - ^8.7.3 : flowforge-file-server
  - ^8.8.0 : flowforge
 postcss
  - ^8.4.19 : forge-ui-components
  - ^8.4.20 : flowforge
 postcss-loader
  - ^6.2.1 : forge-ui-components
  - ^7.0.2 : flowforge
 sass-loader
  - ^12.6.0 : forge-ui-components
  - ^13.2.0 : flowforge
 sinon
  - ^14.0.0 : flowforge-device-agent
  - ^14.0.2 : flowforge, flowforge-nr-file-nodes
 tailwindcss
  - ^2.2.19 : flowforge
  - ^3.2.4 : forge-ui-components
 got
  - 11.8.5 : flowforge-nr-file-nodes, flowforge-nr-persistent-context
  - ^11.8.0 : flowforge-driver-k8s, flowforge-driver-docker
  - ^11.8.2 : flowforge-file-server
  - ^11.8.5 : flowforge-driver-localfs, flowforge-device-agent, flowforge-nr-launcher, flowforge-nr-project-nodes
 @flowforge/file-server
  - ^0.0.4 : flowforge-nr-persistent-context
  - ^0.0.5 : flowforge-nr-file-nodes
```