### PR TITLE
Set eslint to ignore sub-packages

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+package-lock.json
+node_modules
+packages/*
+data/*


### PR DESCRIPTION
I had an issue this morning where VSCode started applying this repo's eslint file (added in https://github.com/flowforge/flowforge-dev-env/pull/17) to all sub-directories.

This simply sets eslint to ignore the sub-packages, as well as a few other files it shouldn't touch.

