### PR TITLE
Stop using npm workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-package-lock.json
 node_modules
 packages/*
 data/*

--- a/README.md
+++ b/README.md
@@ -7,13 +7,15 @@ environment.
 
 1. Clone this repository
 
-2. In the root of this repository run:
+2. Install npm though a [Node version manager](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm#using-a-node-version-manager-to-install-nodejs-and-npm) (e.g. NVM, Volta) or with a [custom global install directory](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally#manually-change-npms-default-directory).
+
+3. In the root of this repository run:
 
        npm install
        npm run init
       
    This will install the immediate dependencies of the development environment,
-   clone all of the required repositories under the `packages` directory then install
+   clone all of the required repositories under the `packages` directory, link the packages to one another, then install
    all of the dependencies of those repositories. It will then run `npm run build`
    on any of the repositories that require it.
 
@@ -24,8 +26,6 @@ flowforge-dev-env
 ├── LICENSE
 ├── README.md
 ├── lib
-├── node_modules
-│   └── ... All module dependencies are hoisted here - using symlinks for local modules
 ├── package.json
 └── packages
     ├── flowforge

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -124,6 +124,36 @@ async function run (options) {
         }
     }
 
+    log(`\n${chalk.bold('Linking npm packages to each other')}`)
+    for (let i = 0; i < options.npm_packages.length; i++) {
+        try {
+            for (let j = 0; j < options.npm_packages.length; j++) {
+                if (i === j) continue;
+
+                const packageToLinkToName = packagePathToName[options.npm_packages[j]]
+                if (packageDependenciesByPath[options.npm_packages[i]].has(packageToLinkToName)) {
+                    const result = await runner(
+                        `npm link to ${packageToLinkToName} from ${options.npm_packages[i]}`,
+                        `npm link ${packageToLinkToName} --fund=false --audit=false`,
+                        { cwd: path.join(options.packageDir, options.npm_packages[i]) }
+                    )
+
+                    log(`${chalk.greenBright('+')} flowforge/${options.npm_packages[i]} linked to ${packageToLinkToName}`)
+                }
+            }
+        } catch (err) {
+            log(`${chalk.redBright('-')} flowforge/${options.npm_packages[i]}`)
+            error(
+                `Failed install link packages for ${
+                    options.packages[i]
+                }: ${err.toString()}`
+            )
+            error(err.stderr)
+            error('Aborting')
+            return
+        }
+    }
+
     log(`\n${chalk.bold('Building packages')}`)
     const buildPackages = ['forge-ui-components', 'flowforge']
     for (let i = 0; i < buildPackages.length; i++) {

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -42,25 +42,29 @@ async function run (options) {
                 `git remote set-url --push origin git@github.com:flowforge/${options.packages[i]}.git`,
                 { cwd: path.join(options.packageDir, options.packages[i]) }
             )
-            log(` ${chalk.yellowBright('=')} flowforge/${options.packages[i]}`)
+            log(`${chalk.yellowBright('=')} flowforge/${options.packages[i]}`)
         }
     }
-    log(chalk.bold('Installing packages'))
-    try {
-        await runner(
-            'npm install',
-            'npm install',
-            { cwd: options.rootDir }
-        )
-        log(`${chalk.greenBright('+')} npm install`)
-    } catch (err) {
-        log(`${chalk.redBright('-')} npm install`)
-        error(`Failed install npm packages: ${err.toString()}`)
-        error(err.stderr)
-        error('Aborting')
-        return
+
+    log(`\n${chalk.bold('Installing packages')}`)
+    for (let i = 0; i < options.packages.length; i++) {
+        try {
+            await runner(
+                `npm install - ${options.packages[i]}`,
+                'npm install',
+                { cwd: path.join(options.packageDir, options.packages[i]) }
+            )
+            log(`${chalk.greenBright('+')} flowforge/${options.packages[i]}`)
+        } catch (err) {
+            log(`${chalk.redBright('-')} flowforge/${options.packages[i]}`)
+            error(`Failed install npm packages for ${options.packages[i]}: ${err.toString()}`)
+            error(err.stderr)
+            error('Aborting')
+            return
+        }
     }
-    log(chalk.bold('Building packages'))
+
+    log(`\n${chalk.bold('Building packages')}`)
     const buildPackages = ['forge-ui-components', 'flowforge']
     for (let i = 0; i < buildPackages.length; i++) {
         const packageName = buildPackages[i]
@@ -81,7 +85,7 @@ async function run (options) {
     }
 
     if (usePGDatabase(options.rootDir)) {
-        log(chalk.bold('Setting up PostgreSQL'))
+        log(`\n${chalk.bold('Setting up PostgreSQL')}`)
 
         const pgDir = path.join(options.rootDir, 'data', 'pg')
         try {

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -1,5 +1,5 @@
 const NPM = process.platform === 'win32' ? 'npm.cmd' : 'npm'
-const { existsSync, mkdirSync, readdirSync, readFileSync } = require('fs')
+const { existsSync, mkdirSync, readdirSync, readFileSync, readlinkSync, realpathSync } = require('fs')
 const { log, error } = require('console')
 const path = require('path')
 const yaml = require('js-yaml')
@@ -46,23 +46,7 @@ async function run (options) {
         }
     }
 
-    log(`\n${chalk.bold('Preparing package symlinks')}`)
-    for (let i = 0; i < options.packages.length; i++) {
-        try {
-            await runner(`npm link for ${options.packages[i]}`, 'npm link', {
-                cwd: path.join(options.packageDir, options.packages[i]),
-            })
-            log(`${chalk.greenBright('+')} flowforge/${options.packages[i]}`)
-        } catch (err) {
-            log(`${chalk.redBright('-')} flowforge/${options.packages[i]}`)
-            error(`Failed to link ${options.packages[i]}: ${err.toString()}`)
-            error(err.stderr)
-            error('Aborting')
-            return
-        }
-    }
-
-    log(`\n${chalk.bold('Linking npm packages to each other')}`)
+    log(`\n${chalk.bold('Reading npm package package.json files and preparing symlinks')}`)
     const packagePathToName = {}
     const packageDependenciesByPath = {}
     for (let i = 0; i < options.npm_packages.length; i++) {
@@ -84,29 +68,38 @@ async function run (options) {
             return
         }
     }
+    const {stdout: npmRootOutput} = await runner('Get npm root', 'npm root -g', {
+        cwd: options.packageDir,
+    })
     for (let i = 0; i < options.npm_packages.length; i++) {
         try {
-            for (let j = 0; j < options.npm_packages.length; j++) {
-                if (i === j) continue;
+            const npmGlobalInstallPath = npmRootOutput.trim()
 
-                const packageToLinkToName = packagePathToName[options.npm_packages[j]]
-                if (packageDependenciesByPath[options.npm_packages[i]].has(packageToLinkToName)) {
-                    await runner(
-                        `npm link to ${packageToLinkToName} from ${options.npm_packages[i]}`,
-                        `npm link ${packageToLinkToName}`,
-                        { cwd: path.join(options.packageDir, options.npm_packages[i]) }
-                    )
-                }
+            const newLinkPath = path.join(options.packageDir, options.npm_packages[i])
+
+            let resolvedExistingLinkPath
+            try { 
+                const existingGlobalLinkLocation = path.join(npmGlobalInstallPath, packagePathToName[options.npm_packages[i]])
+                const existingLinkPath = readlinkSync(existingGlobalLinkLocation)
+
+                const existingLinkDirectory = path.dirname(existingGlobalLinkLocation)
+
+                resolvedExistingLinkPath = path.join(existingLinkDirectory, existingLinkPath)
+            } catch(err) {
+                // No existing link
             }
 
-            log(`${chalk.greenBright('+')} flowforge/${options.npm_packages[i]}`)
+            if (resolvedExistingLinkPath === newLinkPath) {
+                log(`${chalk.yellowBright('=')} flowforge/${options.npm_packages[i]}`)
+            } else {
+                await runner(`npm link for ${options.npm_packages[i]}`, 'npm link', {
+                    cwd: path.join(options.packageDir, options.npm_packages[i]),
+                })
+                log(`${chalk.greenBright('+')} flowforge/${options.npm_packages[i]}`)
+            }
         } catch (err) {
             log(`${chalk.redBright('-')} flowforge/${options.npm_packages[i]}`)
-            error(
-                `Failed install link packages for ${
-                    options.packages[i]
-                }: ${err.toString()}`
-            )
+            error(`Failed to link ${options.npm_packages[i]}: ${err.toString()}`)
             error(err.stderr)
             error('Aborting')
             return

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -46,18 +46,85 @@ async function run (options) {
         }
     }
 
-    log(`\n${chalk.bold('Installing packages')}`)
+    log(`\n${chalk.bold('Preparing package symlinks')}`)
     for (let i = 0; i < options.packages.length; i++) {
         try {
-            await runner(
-                `npm install - ${options.packages[i]}`,
-                'npm install',
-                { cwd: path.join(options.packageDir, options.packages[i]) }
-            )
+            await runner(`npm link for ${options.packages[i]}`, 'npm link', {
+                cwd: path.join(options.packageDir, options.packages[i]),
+            })
             log(`${chalk.greenBright('+')} flowforge/${options.packages[i]}`)
         } catch (err) {
             log(`${chalk.redBright('-')} flowforge/${options.packages[i]}`)
-            error(`Failed install npm packages for ${options.packages[i]}: ${err.toString()}`)
+            error(`Failed to link ${options.packages[i]}: ${err.toString()}`)
+            error(err.stderr)
+            error('Aborting')
+            return
+        }
+    }
+
+    log(`\n${chalk.bold('Linking npm packages to each other')}`)
+    const packagePathToName = {}
+    const packageDependenciesByPath = {}
+    for (let i = 0; i < options.npm_packages.length; i++) {
+        try {
+            const packageFile = path.join(options.packageDir, options.packages[i], 'package.json')
+            const packageDetails = require(packageFile)
+            
+            packagePathToName[options.packages[i]] = packageDetails.name
+            packageDependenciesByPath[options.packages[i]] = new Set()
+
+            const allDependencies = { ...packageDetails.dependencies, ...packageDetails.devDependencies }
+            for (const [name, version] of Object.entries(allDependencies)) {
+                packageDependenciesByPath[options.packages[i]].add(name)
+            }
+        } catch (err) {
+            error(`Failed to read package.json for ${options.packages[i]}: ${err.toString()}`)
+            error(err.stderr)
+            error('Aborting')
+            return
+        }
+    }
+    for (let i = 0; i < options.npm_packages.length; i++) {
+        try {
+            for (let j = 0; j < options.npm_packages.length; j++) {
+                if (i === j) continue;
+
+                const packageToLinkToName = packagePathToName[options.npm_packages[j]]
+                if (packageDependenciesByPath[options.npm_packages[i]].has(packageToLinkToName)) {
+                    await runner(
+                        `npm link to ${packageToLinkToName} from ${options.npm_packages[i]}`,
+                        `npm link ${packageToLinkToName}`,
+                        { cwd: path.join(options.packageDir, options.npm_packages[i]) }
+                    )
+                }
+            }
+
+            log(`${chalk.greenBright('+')} flowforge/${options.npm_packages[i]}`)
+        } catch (err) {
+            log(`${chalk.redBright('-')} flowforge/${options.npm_packages[i]}`)
+            error(
+                `Failed install link packages for ${
+                    options.packages[i]
+                }: ${err.toString()}`
+            )
+            error(err.stderr)
+            error('Aborting')
+            return
+        }
+    }
+
+    log(`\n${chalk.bold('Installing npm packages')}`)
+    for (let i = 0; i < options.npm_packages.length; i++) {
+        try {
+            await runner(
+                `npm install - ${options.npm_packages[i]}`,
+                'npm install',
+                { cwd: path.join(options.packageDir, options.npm_packages[i]) }
+            )
+            log(`${chalk.greenBright('+')} flowforge/${options.npm_packages[i]}`)
+        } catch (err) {
+            log(`${chalk.redBright('-')} flowforge/${options.npm_packages[i]}`)
+            error(`Failed install npm packages for ${options.npm_packages[i]}: ${err.toString()}`)
             error(err.stderr)
             error('Aborting')
             return

--- a/lib/ff-dev-env.js
+++ b/lib/ff-dev-env.js
@@ -27,6 +27,20 @@ options.packages = [
     'docker-compose'
 ]
 
+options.npm_packages = [
+    'flowforge',
+    'forge-ui-components',
+    'flowforge-driver-localfs',
+    'flowforge-driver-k8s',
+    'flowforge-driver-docker',
+    'flowforge-device-agent',
+    'flowforge-file-server',
+    'flowforge-nr-launcher',
+    'flowforge-nr-project-nodes',
+    'flowforge-nr-file-nodes',
+    'flowforge-nr-persistent-context',
+]
+
 options.removedPackages = [
     'flowforge-nr-plugin',
     'flowforge-nr-audit-logger',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,776 @@
+{
+  "name": "flowforge-dev-env",
+  "version": "2.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "flowforge-dev-env",
+      "version": "2.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chalk": "^5.2.0",
+        "command-line-args": "^5.2.1",
+        "command-line-usage": "^6.1.3",
+        "js-yaml": "^4.1.0",
+        "ora": "^6.3.1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "license": "Python-2.0"
+    },
+    "node_modules/array-back": {
+      "version": "3.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bl": {
+      "version": "5.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "6.0.3",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "license": "MIT"
+    },
+    "node_modules/command-line-args": {
+      "version": "5.2.1",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^3.1.0",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "6.1.3",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^4.0.2",
+        "chalk": "^2.4.2",
+        "table-layout": "^1.0.2",
+        "typical": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/array-back": {
+      "version": "4.0.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/chalk": {
+      "version": "2.4.2",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/has-flag": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/supports-color": {
+      "version": "5.5.0",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/typical": {
+      "version": "5.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defaults/node_modules/clone": {
+      "version": "1.0.4",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/find-replace": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "license": "ISC"
+    },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "license": "MIT"
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "6.3.1",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.0.0",
+        "cli-cursor": "^4.0.0",
+        "cli-spinners": "^2.6.1",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^1.1.0",
+        "log-symbols": "^5.1.0",
+        "stdin-discarder": "^0.1.0",
+        "strip-ansi": "^7.0.1",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/cli-cursor": {
+      "version": "4.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/log-symbols": {
+      "version": "5.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.0.0",
+        "is-unicode-supported": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/restore-cursor": {
+      "version": "4.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/reduce-flatten": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "license": "ISC"
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/table-layout": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^4.0.1",
+        "deep-extend": "~0.6.0",
+        "typical": "^5.2.0",
+        "wordwrapjs": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/table-layout/node_modules/array-back": {
+      "version": "4.0.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table-layout/node_modules/typical": {
+      "version": "5.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/typical": {
+      "version": "4.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "license": "MIT"
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/wordwrapjs": {
+      "version": "4.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "reduce-flatten": "^2.0.0",
+        "typical": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/wordwrapjs/node_modules/typical": {
+      "version": "5.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  },
+  "dependencies": {
+    "ansi-styles": {
+      "version": "3.2.1",
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "argparse": {
+      "version": "2.0.1"
+    },
+    "array-back": {
+      "version": "3.1.0"
+    },
+    "base64-js": {
+      "version": "1.5.1"
+    },
+    "bl": {
+      "version": "5.1.0",
+      "requires": {
+        "buffer": "^6.0.3",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.2",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "chalk": {
+      "version": "5.2.0"
+    },
+    "cli-spinners": {
+      "version": "2.9.0"
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3"
+    },
+    "command-line-args": {
+      "version": "5.2.1",
+      "requires": {
+        "array-back": "^3.1.0",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      }
+    },
+    "command-line-usage": {
+      "version": "6.1.3",
+      "requires": {
+        "array-back": "^4.0.2",
+        "chalk": "^2.4.2",
+        "table-layout": "^1.0.2",
+        "typical": "^5.2.0"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "4.0.2"
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5"
+        },
+        "has-flag": {
+          "version": "3.0.0"
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "typical": {
+          "version": "5.2.0"
+        }
+      }
+    },
+    "deep-extend": {
+      "version": "0.6.0"
+    },
+    "defaults": {
+      "version": "1.0.4",
+      "requires": {
+        "clone": "^1.0.2"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "1.0.4"
+        }
+      }
+    },
+    "find-replace": {
+      "version": "3.0.0",
+      "requires": {
+        "array-back": "^3.0.1"
+      }
+    },
+    "ieee754": {
+      "version": "1.2.1"
+    },
+    "inherits": {
+      "version": "2.0.4"
+    },
+    "is-interactive": {
+      "version": "2.0.0"
+    },
+    "js-yaml": {
+      "version": "4.1.0",
+      "requires": {
+        "argparse": "^2.0.1"
+      }
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0"
+    },
+    "mimic-fn": {
+      "version": "2.1.0"
+    },
+    "onetime": {
+      "version": "5.1.2",
+      "requires": {
+        "mimic-fn": "^2.1.0"
+      }
+    },
+    "ora": {
+      "version": "6.3.1",
+      "requires": {
+        "chalk": "^5.0.0",
+        "cli-cursor": "^4.0.0",
+        "cli-spinners": "^2.6.1",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^1.1.0",
+        "log-symbols": "^5.1.0",
+        "stdin-discarder": "^0.1.0",
+        "strip-ansi": "^7.0.1",
+        "wcwidth": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "6.0.1"
+        },
+        "cli-cursor": {
+          "version": "4.0.0",
+          "requires": {
+            "restore-cursor": "^4.0.0"
+          }
+        },
+        "is-unicode-supported": {
+          "version": "1.3.0"
+        },
+        "log-symbols": {
+          "version": "5.1.0",
+          "requires": {
+            "chalk": "^5.0.0",
+            "is-unicode-supported": "^1.1.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "4.0.0",
+          "requires": {
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "strip-ansi": {
+          "version": "7.1.0",
+          "requires": {
+            "ansi-regex": "^6.0.1"
+          }
+        }
+      }
+    },
+    "reduce-flatten": {
+      "version": "2.0.0"
+    },
+    "safe-buffer": {
+      "version": "5.2.1"
+    },
+    "signal-exit": {
+      "version": "3.0.7"
+    },
+    "stdin-discarder": {
+      "version": "0.1.0",
+      "requires": {
+        "bl": "^5.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "table-layout": {
+      "version": "1.0.2",
+      "requires": {
+        "array-back": "^4.0.1",
+        "deep-extend": "~0.6.0",
+        "typical": "^5.2.0",
+        "wordwrapjs": "^4.0.0"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "4.0.2"
+        },
+        "typical": {
+          "version": "5.2.0"
+        }
+      }
+    },
+    "typical": {
+      "version": "4.0.0"
+    },
+    "util-deprecate": {
+      "version": "1.0.2"
+    },
+    "wcwidth": {
+      "version": "1.0.1",
+      "requires": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "wordwrapjs": {
+      "version": "4.0.1",
+      "requires": {
+        "reduce-flatten": "^2.0.0",
+        "typical": "^5.2.0"
+      },
+      "dependencies": {
+        "typical": {
+          "version": "5.2.0"
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "flowforge-dev-env",
   "private": true,
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "A meta repo to create a working FlowForge development environment",
-  "license": "Apache-2.0 ",
+  "license": "Apache-2.0",
   "scripts": {
     "init": "node lib/ff-dev-env.js init",
     "status": "node lib/ff-dev-env.js status",
@@ -12,9 +12,6 @@
     "remove-unused": "node lib/ff-dev-env.js remove-unused",
     "check-dependencies": "node lib/ff-dev-env.js check-dependencies"
   },
-  "workspaces": [
-    "./packages/*"
-  ],
   "dependencies": {
     "chalk": "^5.0.1",
     "command-line-args": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "check-dependencies": "node lib/ff-dev-env.js check-dependencies"
   },
   "dependencies": {
-    "chalk": "^5.0.1",
+    "chalk": "^5.2.0",
     "command-line-args": "^5.2.1",
     "command-line-usage": "^6.1.3",
     "js-yaml": "^4.1.0",
-    "ora": "^6.1.0"
+    "ora": "^6.3.1"
   }
 }


### PR DESCRIPTION
## Description

Stops using npm workspaces, in favour updating the existing script to run `npm install` inside each package manually.

The initial install time is slightly slower, but the speed is comparable after that.

As part of #20 

## Related Issue(s)

#20 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [-] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

