### PR TITLE
NPM Link Improvments

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -4,6 +4,8 @@ const { log, error } = require('console')
 const path = require('path')
 const yaml = require('js-yaml')
 
+const PackageLinker = require('../symlinks')
+
 /**
  * run performs initiation tasks for the developer environment
  *
@@ -46,66 +48,10 @@ async function run (options) {
         }
     }
 
-    log(`\n${chalk.bold('Reading npm package package.json files and preparing symlinks')}`)
-    const packagePathToName = {}
-    const packageDependenciesByPath = {}
-    for (let i = 0; i < options.npm_packages.length; i++) {
-        try {
-            const packageFile = path.join(options.packageDir, options.packages[i], 'package.json')
-            const packageDetails = require(packageFile)
-            
-            packagePathToName[options.packages[i]] = packageDetails.name
-            packageDependenciesByPath[options.packages[i]] = new Set()
-
-            const allDependencies = { ...packageDetails.dependencies, ...packageDetails.devDependencies }
-            for (const [name, version] of Object.entries(allDependencies)) {
-                packageDependenciesByPath[options.packages[i]].add(name)
-            }
-        } catch (err) {
-            error(`Failed to read package.json for ${options.packages[i]}: ${err.toString()}`)
-            error(err.stderr)
-            error('Aborting')
-            return
-        }
-    }
-    const {stdout: npmRootOutput} = await runner('Get npm root', 'npm root -g', {
-        cwd: options.packageDir,
-    })
-    for (let i = 0; i < options.npm_packages.length; i++) {
-        try {
-            const npmGlobalInstallPath = npmRootOutput.trim()
-
-            const newLinkPath = path.join(options.packageDir, options.npm_packages[i])
-
-            let resolvedExistingLinkPath
-            try { 
-                const existingGlobalLinkLocation = path.join(npmGlobalInstallPath, packagePathToName[options.npm_packages[i]])
-                const existingLinkPath = readlinkSync(existingGlobalLinkLocation)
-
-                const existingLinkDirectory = path.dirname(existingGlobalLinkLocation)
-
-                resolvedExistingLinkPath = path.join(existingLinkDirectory, existingLinkPath)
-            } catch(err) {
-                // No existing link
-            }
-
-            if (resolvedExistingLinkPath === newLinkPath) {
-                log(`${chalk.yellowBright('=')} flowforge/${options.npm_packages[i]}`)
-            } else {
-                await runner(`npm link for ${options.npm_packages[i]}`, 'npm link', {
-                    cwd: path.join(options.packageDir, options.npm_packages[i]),
-                })
-                log(`${chalk.greenBright('+')} flowforge/${options.npm_packages[i]}`)
-            }
-        } catch (err) {
-            log(`${chalk.redBright('-')} flowforge/${options.npm_packages[i]}`)
-            error(`Failed to link ${options.npm_packages[i]}: ${err.toString()}`)
-            error(err.stderr)
-            error('Aborting')
-            return
-        }
-    }
-
+    log(`\n${chalk.bold('Reading npm package package.json files and registering global symlinks')}`)
+    const symlinker = new PackageLinker(runner, options.packageDir, options.npm_packages)
+    await symlinker.globallyLinkPackages()
+    
     log(`\n${chalk.bold('Installing npm packages')}`)
     for (let i = 0; i < options.npm_packages.length; i++) {
         try {
@@ -125,34 +71,7 @@ async function run (options) {
     }
 
     log(`\n${chalk.bold('Linking npm packages to each other')}`)
-    for (let i = 0; i < options.npm_packages.length; i++) {
-        try {
-            for (let j = 0; j < options.npm_packages.length; j++) {
-                if (i === j) continue;
-
-                const packageToLinkToName = packagePathToName[options.npm_packages[j]]
-                if (packageDependenciesByPath[options.npm_packages[i]].has(packageToLinkToName)) {
-                    const result = await runner(
-                        `npm link to ${packageToLinkToName} from ${options.npm_packages[i]}`,
-                        `npm link ${packageToLinkToName} --fund=false --audit=false`,
-                        { cwd: path.join(options.packageDir, options.npm_packages[i]) }
-                    )
-
-                    log(`${chalk.greenBright('+')} flowforge/${options.npm_packages[i]} linked to ${packageToLinkToName}`)
-                }
-            }
-        } catch (err) {
-            log(`${chalk.redBright('-')} flowforge/${options.npm_packages[i]}`)
-            error(
-                `Failed install link packages for ${
-                    options.packages[i]
-                }: ${err.toString()}`
-            )
-            error(err.stderr)
-            error('Aborting')
-            return
-        }
-    }
+    await symlinker.linkPackages()
 
     log(`\n${chalk.bold('Building packages')}`)
     const buildPackages = ['forge-ui-components', 'flowforge']

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -49,21 +49,21 @@ async function run (options) {
     }
 
     log(`\n${chalk.bold('Reading npm package package.json files and registering global symlinks')}`)
-    const symlinker = new PackageLinker(runner, options.packageDir, options.npm_packages)
+    const symlinker = new PackageLinker(runner, options.packageDir, options.npmPackages)
     await symlinker.globallyLinkPackages()
     
     log(`\n${chalk.bold('Installing npm packages')}`)
-    for (let i = 0; i < options.npm_packages.length; i++) {
+    for (let i = 0; i < options.npmPackages.length; i++) {
         try {
             await runner(
-                `npm install - ${options.npm_packages[i]}`,
+                `npm install - ${options.npmPackages[i]}`,
                 'npm install',
-                { cwd: path.join(options.packageDir, options.npm_packages[i]) }
+                { cwd: path.join(options.packageDir, options.npmPackages[i]) }
             )
-            log(`${chalk.greenBright('+')} flowforge/${options.npm_packages[i]}`)
+            log(`${chalk.greenBright('+')} flowforge/${options.npmPackages[i]}`)
         } catch (err) {
-            log(`${chalk.redBright('-')} flowforge/${options.npm_packages[i]}`)
-            error(`Failed install npm packages for ${options.npm_packages[i]}: ${err.toString()}`)
+            log(`${chalk.redBright('-')} flowforge/${options.npmPackages[i]}`)
+            error(`Failed install npm packages for ${options.npmPackages[i]}: ${err.toString()}`)
             error(err.stderr)
             error('Aborting')
             return
@@ -71,7 +71,7 @@ async function run (options) {
     }
 
     log(`\n${chalk.bold('Linking npm packages to each other')}`)
-    await symlinker.linkPackages()
+    await symlinker.linkPackages(options.extraNpmLinks)
 
     log(`\n${chalk.bold('Building packages')}`)
     const buildPackages = ['forge-ui-components', 'flowforge']

--- a/lib/commands/link.js
+++ b/lib/commands/link.js
@@ -10,11 +10,11 @@ async function run (options) {
     const { runner } = await require('../runner')()
 
     log(`\n${chalk.bold('Reading npm package package.json files and preparing symlinks')}`)
-    const symlinker = new PackageLinker(runner, options.packageDir, options.npm_packages)
+    const symlinker = new PackageLinker(runner, options.packageDir, options.npmPackages)
     await symlinker.globallyLinkPackages()
 
     log(`\n${chalk.bold('Linking npm packages to one another')}`)
-    await symlinker.linkPackages()
+    await symlinker.linkPackages(options.extraNpmLinks)
 }
 
 module.exports = {

--- a/lib/commands/link.js
+++ b/lib/commands/link.js
@@ -1,0 +1,22 @@
+const { existsSync } = require('fs')
+const { log } = require('console')
+const path = require('path')
+
+const PackageLinker = require('../symlinks')
+
+async function run (options) {
+    const chalk = (await import('chalk')).default
+
+    const { runner } = await require('../runner')()
+
+    log(`\n${chalk.bold('Reading npm package package.json files and preparing symlinks')}`)
+    const symlinker = new PackageLinker(runner, options.packageDir, options.npm_packages)
+    await symlinker.globallyLinkPackages()
+
+    log(`\n${chalk.bold('Linking npm packages to one another')}`)
+    await symlinker.linkPackages()
+}
+
+module.exports = {
+    run
+}

--- a/lib/ff-dev-env.js
+++ b/lib/ff-dev-env.js
@@ -27,7 +27,7 @@ options.packages = [
     'docker-compose'
 ]
 
-options.npm_packages = [
+options.npmPackages = [
     'flowforge',
     'forge-ui-components',
     'flowforge-driver-localfs',
@@ -41,6 +41,10 @@ options.npm_packages = [
     'flowforge-nr-persistent-context',
 ]
 
+options.extraNpmLinks = {
+    'flowforge': ['@flowforge/localfs', '@flowforge/kubernetes', '@flowforge/docker'],
+}
+
 options.removedPackages = [
     'flowforge-nr-plugin',
     'flowforge-nr-audit-logger',
@@ -48,6 +52,8 @@ options.removedPackages = [
     'flowforge-nr-storage',
     'flowforge-nr-theme'
 ]
+
+
 
 if (options.command === 'remove-unused') {
     require('./commands/removeUnused').run(options)

--- a/lib/ff-dev-env.js
+++ b/lib/ff-dev-env.js
@@ -57,6 +57,8 @@ if (options.command === 'remove-unused') {
         require('./commands/init').run(options)
     } else if (options.command === 'status') {
         require('./commands/status').run(options)
+    } else if (options.command === 'link') {
+        require('./commands/link').run(options)
     } else if (options.command === 'update') {
         require('./commands/update').run(options)
     } else if (options.command === 'git') {

--- a/lib/symlinks.js
+++ b/lib/symlinks.js
@@ -1,5 +1,6 @@
 const { log, error } = require('console')
 const path = require('path')
+const { readlinkSync } = require('fs')
 
 module.exports = class PackageLinker {
     constructor(runner, packageDir, packagePathsToLoad = []) {
@@ -66,7 +67,7 @@ module.exports = class PackageLinker {
                 try {
                     const existingGlobalLinkLocation = path.join(
                         npmGlobalInstallPath,
-                        packagePathToName[this.npmPackagePaths[i]]
+                        packagesByPath[this.npmPackagePaths[i]].name
                     )
                     const existingLinkPath = readlinkSync(existingGlobalLinkLocation)
 
@@ -115,17 +116,19 @@ module.exports = class PackageLinker {
                     }
                 }
 
-                const packageNamesToLinkTo = packagesToLinkTo.map((pkg) => pkg.name)
-                const packageNamesString = packageNamesToLinkTo.join(', ')
-                const result = await this.runner(
-                    `npm link to ${packageNamesString}; from ${packageToLinkFrom.name}`,
-                    `npm link ${packageNamesToLinkTo.join(' ')} --fund=false --audit=false`,
-                    { cwd: path.join(this.packageDir, packageToLinkFromPath) }
-                )
+                if (packagesToLinkTo.length > 0) {
+                    const packageNamesToLinkTo = packagesToLinkTo.map((pkg) => pkg.name)
+                    const packageNamesString = packageNamesToLinkTo.join(', ')
+                    const result = await this.runner(
+                        `npm link to ${packageNamesString}; from ${packageToLinkFrom.name}`,
+                        `npm link ${packageNamesToLinkTo.join(' ')} --fund=false --audit=false`,
+                        { cwd: path.join(this.packageDir, packageToLinkFromPath) }
+                    )
 
-                log(
-                    `${chalk.greenBright('+')} flowforge/${packageToLinkFromPath} linked to ${packageNamesString}`
-                )
+                    log(
+                        `${chalk.greenBright('+')} flowforge/${packageToLinkFromPath} linked to ${packageNamesString}`
+                    )
+                }
             } catch (err) {
                 log(`${chalk.redBright('-')} flowforge/${packageToLinkFromPath}`)
                 error(`Failed install link packages for ${packageToLinkFromPath.name}: ${err.toString()}`)

--- a/lib/symlinks.js
+++ b/lib/symlinks.js
@@ -96,7 +96,7 @@ module.exports = class PackageLinker {
         }
     }
 
-    async linkPackages() {
+    async linkPackages(extraLinks = {}) {
         const packagesByPath = await this.getInfoForPackages()
         const chalk = (await import('chalk')).default
 
@@ -115,12 +115,17 @@ module.exports = class PackageLinker {
                         packagesToLinkTo.push(packageToLinkTo)
                     }
                 }
+                
+                // Optional extra links not found in package.json
+                if (extraLinks[packageToLinkFromPath]) {
+                    packagesToLinkTo.push(...extraLinks[packageToLinkFromPath].map((pkg) => { return { name: pkg } }))
+                }
 
                 if (packagesToLinkTo.length > 0) {
                     const packageNamesToLinkTo = packagesToLinkTo.map((pkg) => pkg.name)
                     const packageNamesString = packageNamesToLinkTo.join(', ')
                     const result = await this.runner(
-                        `npm link to ${packageNamesString}; from ${packageToLinkFrom.name}`,
+                        `npm link from ${packageToLinkFrom.name} to ${packageNamesString}`,
                         `npm link ${packageNamesToLinkTo.join(' ')} --fund=false --audit=false`,
                         { cwd: path.join(this.packageDir, packageToLinkFromPath) }
                     )

--- a/lib/symlinks.js
+++ b/lib/symlinks.js
@@ -1,0 +1,139 @@
+const { log, error } = require('console')
+const path = require('path')
+
+module.exports = class PackageLinker {
+    constructor(runner, packageDir, packagePathsToLoad = []) {
+        this.runner = runner
+
+        this.packageDir = packageDir
+        this.npmPackagePaths = packagePathsToLoad
+    }
+
+    async getInfoForPackages() {
+        if (this.packagesByPath) {
+            return this.packagesByPath
+        }
+
+        const packages = {}
+
+        for (let i = 0; i < this.npmPackagePaths.length; i++) {
+            const packagePath = this.npmPackagePaths[i]
+
+            try {
+                const packageFile = path.join(this.packageDir, packagePath, 'package.json')
+                const packageDetails = require(packageFile)
+
+                const packageSummary = {
+                    name: packageDetails.name,
+                    dependencies: new Set(),
+                }
+
+                const allDependencies = { ...packageDetails.dependencies, ...packageDetails.devDependencies }
+                for (const [name, version] of Object.entries(allDependencies)) {
+                    packageSummary.dependencies.add(name)
+                }
+
+                packages[packagePath] = packageSummary
+            } catch (err) {
+                error(`Failed to read package.json for ${packagePath}: ${err.toString()}`)
+                error(err.stderr)
+                error('Aborting')
+                return
+            }
+        }
+
+        this.packagesByPath = packages
+
+        return this.packagesByPath
+    }
+
+    async globallyLinkPackages() {
+        const packagesByPath = await this.getInfoForPackages()
+        const chalk = (await import('chalk')).default
+
+        const { stdout: npmRootOutput } = await this.runner('Get npm root', 'npm root -g', {
+            cwd: this.packageDir,
+        })
+        for (let i = 0; i < this.npmPackagePaths.length; i++) {
+            const packagePath = this.npmPackagePaths[i]
+
+            try {
+                const npmGlobalInstallPath = npmRootOutput.trim()
+
+                const newLinkPath = path.join(this.packageDir, this.npmPackagePaths[i])
+
+                let resolvedExistingLinkPath
+                try {
+                    const existingGlobalLinkLocation = path.join(
+                        npmGlobalInstallPath,
+                        packagePathToName[this.npmPackagePaths[i]]
+                    )
+                    const existingLinkPath = readlinkSync(existingGlobalLinkLocation)
+
+                    const existingLinkDirectory = path.dirname(existingGlobalLinkLocation)
+
+                    resolvedExistingLinkPath = path.join(existingLinkDirectory, existingLinkPath)
+                } catch (err) {
+                    // No existing link
+                }
+
+                if (resolvedExistingLinkPath === newLinkPath) {
+                    log(`${chalk.yellowBright('=')} flowforge/${this.npmPackagePaths[i]}`)
+                } else {
+                    await this.runner(`npm link for ${this.npmPackagePaths[i]}`, 'npm link', {
+                        cwd: path.join(this.packageDir, this.npmPackagePaths[i]),
+                    })
+                    log(`${chalk.greenBright('+')} flowforge/${this.npmPackagePaths[i]}`)
+                }
+            } catch (err) {
+                log(`${chalk.redBright('-')} flowforge/${this.npmPackagePaths[i]}`)
+                error(`Failed to link ${this.npmPackagePaths[i]}: ${err.toString()}`)
+                error(err.stderr)
+                error('Aborting')
+                return
+            }
+        }
+    }
+
+    async linkPackages() {
+        const packagesByPath = await this.getInfoForPackages()
+        const chalk = (await import('chalk')).default
+
+        for (let i = 0; i < this.npmPackagePaths.length; i++) {
+            const packageToLinkFromPath = this.npmPackagePaths[i]
+            const packageToLinkFrom = packagesByPath[packageToLinkFromPath]
+
+            try {
+                const packagesToLinkTo = []
+                for (let j = 0; j < this.npmPackagePaths.length; j++) {
+                    if (i === j) continue
+
+                    const packageToLinkTo = packagesByPath[this.npmPackagePaths[j]]
+                    const packageToLinkToName = packageToLinkTo.name
+                    if (packageToLinkFrom.dependencies.has(packageToLinkToName)) {
+                        packagesToLinkTo.push(packageToLinkTo)
+                    }
+                }
+
+                const packageNamesToLinkTo = packagesToLinkTo.map((pkg) => pkg.name)
+                const packageNamesString = packageNamesToLinkTo.join(', ')
+                const result = await this.runner(
+                    `npm link to ${packageNamesString}; from ${packageToLinkFrom.name}`,
+                    `npm link ${packageNamesToLinkTo.join(' ')} --fund=false --audit=false`,
+                    { cwd: path.join(this.packageDir, packageToLinkFromPath) }
+                )
+
+                log(
+                    `${chalk.greenBright('+')} flowforge/${packageToLinkFromPath} linked to ${packageNamesString}`
+                )
+            } catch (err) {
+                log(`${chalk.redBright('-')} flowforge/${packageToLinkFromPath}`)
+                error(`Failed install link packages for ${packageToLinkFromPath.name}: ${err.toString()}`)
+                console.log(err)
+                error(err.stderr)
+                error('Aborting')
+                return
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "init": "node lib/ff-dev-env.js init",
     "status": "node lib/ff-dev-env.js status",
+    "link": "node lib/ff-dev-env.js link",
     "update": "node lib/ff-dev-env.js update",
     "git": "node lib/ff-dev-env.js git",
     "remove-unused": "node lib/ff-dev-env.js remove-unused",


### PR DESCRIPTION
## Description

For https://github.com/flowforge/flowforge-dev-env/issues/20, follow up to https://github.com/flowforge/flowforge-dev-env/pull/21

This PR:
 - Introduces a new command `npm link` that solely runs linking of NPM packages
 - Updates linking to handle it all in one go per repo
 - Adds support to manually specify additional links not in package.json (see `options.extraNpmLinks`)

Behind the scenes it:
 - Extract linking logic into a lib so it can run on init and manual link

Please test this locally by:
 - Pulling `flowforge-dev-env` to a clean directory and running `npm run init` (after an install)
 - Swapping your existing dev-env to this branch, and running `npm run link`, then manually checking your `node_modules` directories for symlinks

This PR should resolve the issues @knolleary hit locally with #21 

## Related Issue(s)

#20 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [-] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

