### PR TITLE
Skip Forge UI Components Linking

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -71,7 +71,7 @@ async function run (options) {
     }
 
     log(`\n${chalk.bold('Linking npm packages to each other')}`)
-    await symlinker.linkPackages(options.extraNpmLinks)
+    await symlinker.linkPackages(options.extraNpmLinks, options.disabledNpmLinks)
 
     log(`\n${chalk.bold('Building packages')}`)
     const buildPackages = ['forge-ui-components', 'flowforge']

--- a/lib/commands/link.js
+++ b/lib/commands/link.js
@@ -14,7 +14,7 @@ async function run (options) {
     await symlinker.globallyLinkPackages()
 
     log(`\n${chalk.bold('Linking npm packages to one another')}`)
-    await symlinker.linkPackages(options.extraNpmLinks)
+    await symlinker.linkPackages(options.extraNpmLinks, options.disabledNpmLinks)
 }
 
 module.exports = {

--- a/lib/ff-dev-env.js
+++ b/lib/ff-dev-env.js
@@ -46,6 +46,7 @@ options.extraNpmLinks = {
 }
 
 options.disabledNpmLinks = {
+    'flowforge': ['@flowforge/forge-ui-components'],
 }
 
 options.removedPackages = [

--- a/lib/ff-dev-env.js
+++ b/lib/ff-dev-env.js
@@ -45,6 +45,9 @@ options.extraNpmLinks = {
     'flowforge': ['@flowforge/localfs', '@flowforge/kubernetes', '@flowforge/docker'],
 }
 
+options.disabledNpmLinks = {
+}
+
 options.removedPackages = [
     'flowforge-nr-plugin',
     'flowforge-nr-audit-logger',

--- a/lib/symlinks.js
+++ b/lib/symlinks.js
@@ -96,7 +96,7 @@ module.exports = class PackageLinker {
         }
     }
 
-    async linkPackages(extraLinks = {}) {
+    async linkPackages(extraLinks = {}, disabledLinks = {}) {
         const packagesByPath = await this.getInfoForPackages()
         const chalk = (await import('chalk')).default
 
@@ -105,7 +105,7 @@ module.exports = class PackageLinker {
             const packageToLinkFrom = packagesByPath[packageToLinkFromPath]
 
             try {
-                const packagesToLinkTo = []
+                let packagesToLinkTo = []
                 for (let j = 0; j < this.npmPackagePaths.length; j++) {
                     if (i === j) continue
 
@@ -119,6 +119,12 @@ module.exports = class PackageLinker {
                 // Optional extra links not found in package.json
                 if (extraLinks[packageToLinkFromPath]) {
                     packagesToLinkTo.push(...extraLinks[packageToLinkFromPath].map((pkg) => { return { name: pkg } }))
+                }
+
+                // Remove any disabled links
+                if (disabledLinks[packageToLinkFromPath]) {
+                    const packagesToSkip = disabledLinks[packageToLinkFromPath]
+                    packagesToLinkTo = packagesToLinkTo.filter((pkg) => packagesToSkip.includes(pkg.name) === false) 
                 }
 
                 if (packagesToLinkTo.length > 0) {


### PR DESCRIPTION

## Description

There's an issue with forge-ui-components when linked locally that stops flowforge/flowforge from behaving correctly.
This PR skips linking that locally so the development team are unblocked.

- Optionally skip packages linking
- Disable forge-ui-components package linking


## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

